### PR TITLE
fix: default.nix is no longer fixed to remote repo + small improvements

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -10,7 +10,7 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "aphorme";
-  version = "0.1.19";
+  version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package.version;
 
   src = lib.cleanSourceWith {
     src = ./.;

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,5 @@
 { lib
-, fetchFromGitHub
+, libGL
 , rustPlatform
 , fontconfig
 , pkg-config
@@ -10,16 +10,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "aphorme";
-  version = "0.1.18";
+  version = "0.1.19";
 
-  src = fetchFromGitHub {
-    owner = "Iaphetes";
-    repo = "aphorme_launcher";
-    rev = lib.fakeHash;
-    hash = lib.fakeHash;
+  src = lib.cleanSourceWith {
+    src = ./.;
+    filter = path: type:
+      type == "directory" || lib.hasSuffix ".rs" path
+      || lib.hasSuffix ".toml" path || lib.hasSuffix "Cargo.lock" path;
   };
 
-  cargoHash = lib.fakeHash;
+  cargoLock.lockFile = ./Cargo.lock;
 
   # No tests exist
   doCheck = false;

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1716220750,
+        "narHash": "sha256-Lhhrd1ZBNXCbUupWGq6gRPIy1qMKEdcAXcjnwgVqe/U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "641daa314d5bc1bca4b345da8eb08a130b109c79",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,17 @@
+{
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+  outputs = { nixpkgs, ... }:
+    let
+      supportedSystems = [ "aarch64-linux" "i686-linux" "x86_64-linux" ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+    in {
+      packages = forAllSystems (system: {
+        default = nixpkgs.legacyPackages.${system}.callPackage ./default.nix { };
+      });
+
+      devShells = forAllSystems (system: {
+        default = nixpkgs.legacyPackages.${system}.callPackage ./shell.nix { };
+      });
+    };
+}


### PR DESCRIPTION
- Updated version to current tag
- Replaced remote `src` with local `src`
  - `src` is now filtered to prevent unneeded rebuilds
- Use `Cargo.lock` directly instead of having to manually specify hash
- Added missing `libGL` to inputs